### PR TITLE
refactor: add koin inject utilities

### DIFF
--- a/shared/src/commonMain/kotlin/com/uwaisalqadri/mangaku/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/uwaisalqadri/mangaku/di/Koin.kt
@@ -15,7 +15,9 @@ import com.uwaisalqadri.mangaku.utils.resourceReaderModule
 import org.koin.core.Koin
 import org.koin.core.KoinApplication
 import org.koin.core.context.startKoin
+import org.koin.core.qualifier.named
 import org.koin.dsl.KoinAppDeclaration
+import org.koin.mp.KoinPlatformTools
 
 fun initKoin(appDeclaration: KoinAppDeclaration = {}): KoinApplication {
     return startKoin {
@@ -54,3 +56,21 @@ val Koin.addMangaUseCase: AddMangaUseCase
 
 val Koin.deleteMangaUseCase: DeleteMangaUseCase
     get() = get()
+
+// Koin utilities for injection (jvm, iosarm64, iossimulatorarm64, iosx64)
+
+inline fun <reified T : Any> injectLazy(): Lazy<T> {
+    return lazy { KoinPlatformTools.defaultContext().get().get(T::class) }
+}
+
+inline fun <reified T : Any> injectLazy(key: String): Lazy<T> {
+    return lazy { KoinPlatformTools.defaultContext().get().get(T::class, named(key)) }
+}
+
+inline fun <reified T : Any> inject(): T {
+    return KoinPlatformTools.defaultContext().get().get(T::class)
+}
+
+inline fun <reified T : Any> inject(key: String): T {
+    return KoinPlatformTools.defaultContext().get().get(T::class, named(key))
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added Koin Utilities

## What is the current behavior?

Returning the object/class immediately by calling get() using extension function

## What is the new behavior?

Use reflection and generics to get injected object/class and add support for lazy injection

## Example use

```kotlin
// immediate
val browseUseCase = inject<BrowseUseCase>
val browseUseCase: BrowseUseCase = inject()
// named immediate
val comickMangaApi = inject("comick")<MangaApi>
val asurascansMangaApi = inject("asurascans")<MangaApi>

// lazy
val browseUseCase by injectLazy<BrowseUseCase>()
val browseUseCase: BrowseUseCase by injectLazy()
// named lazy
val comickMangaApi: MangaApi by injectLazy("comick")
val asurascansMangaApi: MangaApi by injectLazy("asurascans")
```